### PR TITLE
WoopraTracker should have support for composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,16 @@ The purpose of this SDK is to allow our customers who have servers running PHP t
 - through the front-end: after configuring the tracker, identifying the user, and tracking page views and events in PHP, the SDK will generate the corresponding JavaScript code, and you will be able to print that code in your pages' headers.
 - through the back-end: after configuring the tracker & identifying the user, add the optional parameter TRUE to the methods <code>track</code> or <code>push</code>, and the PHP tracker will handle sending the data to Woopra by making HTTP Requests. By doing that, the client is never involved in the tracking process.
 
+The best way to install Woopra/Woopra-php-sdk is using [Composer](getcomposer.org)
+
+``` sh
+$ composer require woopra/woopra-php-sdk
+```
+
 The first step is to setup the tracker SDK. To do so, import the woopra_tracker.php file then configure the tracker instance as follows (replace mybusiness.com with your website as registered on Woopra):
 ``` php
 require_once('woopra_tracker.php');
+// require_once('vendor/autoload.php'); // for composer installation
 $woopra = new WoopraTracker(array("domain" => "mybusiness.com"));
 ```
 You can update your idle timeout (default: 30 seconds) by updating the timeout property in your WoopraTracker instance (NB: this could also have been done in the step above, by adding all the properties you wish to configure to the array):

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "woopra/woopra-php-sdk",
+    "description": "Woopra.com PHP SDK",
+    "authors": [ ],
+    "autoload": {
+        "classmap": ["woopra_tracker.php"]
+    }
+}


### PR DESCRIPTION
WoopraTracker should have support for [composer](http://getcomposer.org)

If you merge this pull request. Please register package at [packagist.org](http://packagist.org)

You should add authors in `package.json` like this.

``` json
...
"authors": [
    {
        "name": "An Author",
        "homepage": "http://example.com"
    },
    {
        "name": "Another Author",
        "homepage": "http://example.com"
    }
]
...
```
